### PR TITLE
Add wrap and metadata support in SaloonResponseFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This package requires Laravel 10.0 or higher and PHP 8.1 or higher.
 
 You can use factories to create fake data for your Saloon tests
 
+To create a factory you should extend the SaloonResponseFactory class and implement the definition method.
+
 ```php
 namespace Tests\SaloonResponseFactories;
 
@@ -46,8 +48,6 @@ class PostResponseFactoryFactory extends SaloonResponseFactory
 }
 ```
 
-To create a factory you should extend the SaloonResponseFactory class and implement the definition method.
-
 You can use the faker property to generate fake data.
 
 ```php
@@ -60,6 +60,104 @@ it('should get the post', function () {
     ]);
 });
 ```
+
+### Wrapping the response
+
+You can use the wrap method to wrap the response in a custom structure.
+
+```php
+namespace Tests\SaloonResponseFactories;
+
+use BitMx\SaloonResponseFactories\Factories\SaloonResponseFactory;
+
+class PostResponseFactoryFactory extends SaloonResponseFactory
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function definition(): array
+    {
+        return [
+            'id' => $this->faker->unique()->randomNumber(),
+            'title' => $this->faker->sentence(),
+            'content' => $this->faker->paragraph(),
+        ];
+    }
+    
+    public function wrap(): string
+    {
+        return 'data';
+    }
+}
+```
+
+This create a response like this:
+
+```php
+
+\Saloon\Http\Faking\MockResponse::make([
+    'data' => [
+        'id' => 1,
+        'title' => 'Title 1',
+        'content' => 'Content 1',
+    ],
+]);
+```
+
+### Metadata
+
+You can use the metadata method to add metadata to the response.
+
+```php
+
+namespace Tests\SaloonResponseFactories;
+
+use BitMx\SaloonResponseFactories\Factories\SaloonResponseFactory;
+
+class PostResponseFactoryFactory extends SaloonResponseFactory
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function definition(): array
+    {
+        return [
+            'id' => $this->faker->unique()->randomNumber(),
+            'title' => $this->faker->sentence(),
+            'content' => $this->faker->paragraph(),
+        ];
+    }
+    
+    public function wrap(): string{
+        return 'data';
+    }
+    
+    public function metadata(): array
+    {
+        return [
+            'total' => 10,
+        ];
+    }
+}
+```
+
+This creates a response like this:
+
+```php
+
+\Saloon\Http\Faking\MockResponse::make([
+    'data' => [
+        'id' => 1,
+        'title' => 'Title 1',
+        'content' => 'Content 1',
+    ],
+    'metadata' => [
+        'total' => 10,
+    ],
+]);
+```
+
+### Count
 
 You can also use the count method to create an array of fake data.
 

--- a/src/Factories/FactoryData.php
+++ b/src/Factories/FactoryData.php
@@ -10,6 +10,7 @@ class FactoryData
      * @param  array<array-key, mixed>  $definedHeaders
      * @param  array<array-key, mixed>  $headers
      * @param  array<array-key, mixed>  $without
+     * @param  array<array-key, mixed>  $metadata
      */
     public function __construct(
         private readonly array $definition,
@@ -18,6 +19,8 @@ class FactoryData
         private readonly array $headers,
         private readonly array $without,
         private readonly int $status = 200,
+        private readonly string $wrap = 'data',
+        private readonly array $metadata = [],
     ) {
     }
 
@@ -25,6 +28,22 @@ class FactoryData
      * @return array<array-key, mixed>
      */
     public function getBody(int $times = 1): array
+    {
+        $body = $this->createBody($times);
+
+        $wrappedBody = $this->wrapBody($body);
+
+        return [
+            ...$wrappedBody,
+            ...$this->metadata,
+        ];
+
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    protected function createBody(int $times): array
     {
         if ($times === 1) {
             return $this->getData();
@@ -59,6 +78,19 @@ class FactoryData
     public function getWithout(): array
     {
         return $this->without;
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $body
+     * @return array<array-key, mixed>
+     */
+    protected function wrapBody(array $body): array
+    {
+        if ($this->wrap) {
+            return [$this->wrap => $body];
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Factories/SaloonResponseFactory.php
+++ b/src/Factories/SaloonResponseFactory.php
@@ -118,6 +118,8 @@ abstract class SaloonResponseFactory
             headers: $this->headers,
             without: $this->without,
             status: $this->status ?? 200,
+            wrap: $this->defaultWrap(),
+            metadata: $this->metadata(),
         );
     }
 
@@ -130,6 +132,19 @@ abstract class SaloonResponseFactory
      * @return array<array-key, mixed>
      */
     public function withHeaders(): array
+    {
+        return [];
+    }
+
+    public function defaultWrap(): string
+    {
+        return '';
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function metadata(): array
     {
         return [];
     }

--- a/tests/Unit/SaloonResponseFactoryTest.php
+++ b/tests/Unit/SaloonResponseFactoryTest.php
@@ -4,8 +4,7 @@ use BitMx\SaloonResponseFactories\Factories\SaloonResponseFactory;
 use Saloon\Http\Faking\MockResponse;
 
 beforeEach(function () {
-    $this->factory = new class extends SaloonResponseFactory
-    {
+    $this->factory = new class extends SaloonResponseFactory {
         public function definition(): array
         {
             return [
@@ -20,9 +19,68 @@ it('creates a new instance of SaloonResponseFactory', function () {
 });
 
 it('gets the definition from the factory', function () {
-
     expect($this->factory->create())->toBeInstanceOf(MockResponse::class)
         ->and($this->factory->create()->body()->all())->toBe(['name' => 'John Doe']);
+});
+
+it('gets the definition from the factory wrapped with wrap method', function () {
+    $factory = new class extends SaloonResponseFactory {
+        public function definition(): array
+        {
+            return [
+                'name' => 'John Doe',
+            ];
+        }
+
+        public function defaultWrap(): string
+        {
+            return 'data';
+        }
+    };
+
+    expect($factory->create())->toBeInstanceOf(MockResponse::class)
+        ->and($factory->create()->body()->all())->toBe(['data' => ['name' => 'John Doe']]);
+});
+
+it('gets the definition from the factory wrapped with wrap method and metadata', function () {
+    $factory = new class extends SaloonResponseFactory {
+        public function definition(): array
+        {
+            return [
+                'name' => 'John Doe',
+            ];
+        }
+
+        public function defaultWrap(): string
+        {
+            return 'data';
+        }
+
+        public function metadata(): array
+        {
+            return [
+                'metadata' => [
+                    'page' => 1,
+                    'total' => 10,
+                ],
+                'response' => [
+                    'status' => 'success',
+                ],
+            ];
+        }
+    };
+
+    expect($factory->create())->toBeInstanceOf(MockResponse::class)
+        ->and($factory->create()->body()->all())->toBe([
+            'data' => ['name' => 'John Doe'],
+            'metadata' => [
+                'page' => 1,
+                'total' => 10,
+            ],
+            'response' => [
+                'status' => 'success',
+            ],
+        ]);
 });
 
 it('creates a new state', function () {
@@ -38,6 +96,51 @@ it('creates a array with n times the definition', function () {
         ['name' => 'John Doe'],
         ['name' => 'John Doe'],
         ['name' => 'John Doe'],
+    ]);
+});
+
+it('creates a array with n times the definition wrapped with data', function () {
+
+    $factory = new class extends SaloonResponseFactory {
+        public function definition(): array
+        {
+            return [
+                'name' => 'John Doe',
+            ];
+        }
+
+        public function defaultWrap(): string
+        {
+            return 'data';
+        }
+
+        public function metadata(): array
+        {
+            return [
+                'metadata' => [
+                    'page' => 1,
+                    'total' => 10,
+                ],
+                'response' => [
+                    'status' => 'success',
+                ],
+            ];
+        }
+    };
+
+    expect($factory->count(3)->create()->body()->all())->toBe([
+        'data' => [
+            ['name' => 'John Doe'],
+            ['name' => 'John Doe'],
+            ['name' => 'John Doe'],
+        ],
+        'metadata' => [
+            'page' => 1,
+            'total' => 10,
+        ],
+        'response' => [
+            'status' => 'success',
+        ],
     ]);
 });
 
@@ -83,8 +186,7 @@ it('overrides the definition with the attributes and the array on creates method
 });
 
 it('add headers to response', function () {
-    $factory = new class extends SaloonResponseFactory
-    {
+    $factory = new class extends SaloonResponseFactory {
         public function definition(): array
         {
             return [
@@ -105,8 +207,7 @@ it('add headers to response', function () {
 });
 
 it('overrides the headers with the headers array', function () {
-    $factory = new class extends SaloonResponseFactory
-    {
+    $factory = new class extends SaloonResponseFactory {
         public function definition(): array
         {
             return [

--- a/tests/Unit/SaloonResponseFactoryTest.php
+++ b/tests/Unit/SaloonResponseFactoryTest.php
@@ -4,7 +4,8 @@ use BitMx\SaloonResponseFactories\Factories\SaloonResponseFactory;
 use Saloon\Http\Faking\MockResponse;
 
 beforeEach(function () {
-    $this->factory = new class extends SaloonResponseFactory {
+    $this->factory = new class extends SaloonResponseFactory
+    {
         public function definition(): array
         {
             return [
@@ -24,7 +25,8 @@ it('gets the definition from the factory', function () {
 });
 
 it('gets the definition from the factory wrapped with wrap method', function () {
-    $factory = new class extends SaloonResponseFactory {
+    $factory = new class extends SaloonResponseFactory
+    {
         public function definition(): array
         {
             return [
@@ -43,7 +45,8 @@ it('gets the definition from the factory wrapped with wrap method', function () 
 });
 
 it('gets the definition from the factory wrapped with wrap method and metadata', function () {
-    $factory = new class extends SaloonResponseFactory {
+    $factory = new class extends SaloonResponseFactory
+    {
         public function definition(): array
         {
             return [
@@ -101,7 +104,8 @@ it('creates a array with n times the definition', function () {
 
 it('creates a array with n times the definition wrapped with data', function () {
 
-    $factory = new class extends SaloonResponseFactory {
+    $factory = new class extends SaloonResponseFactory
+    {
         public function definition(): array
         {
             return [
@@ -186,7 +190,8 @@ it('overrides the definition with the attributes and the array on creates method
 });
 
 it('add headers to response', function () {
-    $factory = new class extends SaloonResponseFactory {
+    $factory = new class extends SaloonResponseFactory
+    {
         public function definition(): array
         {
             return [
@@ -207,7 +212,8 @@ it('add headers to response', function () {
 });
 
 it('overrides the headers with the headers array', function () {
-    $factory = new class extends SaloonResponseFactory {
+    $factory = new class extends SaloonResponseFactory
+    {
         public function definition(): array
         {
             return [


### PR DESCRIPTION
This update extends SaloonResponseFactory to include optional support for metadata and wrapped responses. The factory can now wrap the response in a custom structure, and metadata can be added to the response. The README and unit tests have been adjusted to reflect these additions.