### PR TITLE
Add custom status code feature to SaloonResponseFactory

### DIFF
--- a/src/Factories/SaloonResponseFactory.php
+++ b/src/Factories/SaloonResponseFactory.php
@@ -52,9 +52,9 @@ abstract class SaloonResponseFactory
     protected function newInstance(
         array $attributes = [],
         array $without = [],
-        int $status = 200,
+        ?int $status = null,
         array $headers = [],
-        int $times = 1,
+        ?int $times = null,
     ): static {
         return new static(
             attributes: array_replace_recursive(
@@ -65,9 +65,9 @@ abstract class SaloonResponseFactory
                 $this->without,
                 $without,
             ),
-            status: $status,
+            status: $status ?? $this->status,
             headers: array_replace_recursive($this->headers, $headers),
-            times: $times,
+            times: $times ?? $this->times,
         );
     }
 

--- a/tests/Unit/SaloonResponseFactoryTest.php
+++ b/tests/Unit/SaloonResponseFactoryTest.php
@@ -242,3 +242,7 @@ it('overrides the headers with the headers array', function () {
     ]);
 
 });
+
+it('creates a response with custom status code', function () {
+    expect($this->factory->status(500)->create()->status())->toBe(500);
+});


### PR DESCRIPTION
A change was made to the SaloonResponseFactory and corresponding tests that allows custom HTTP status codes to be set. This is achieved by updating the factory's newInstance method to optionally accept a custom status code. The corresponding unit tests were also updated to validate this new functionality.